### PR TITLE
Nested focus containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .dvlp/
 node_modules/
+
+.vercel

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "start": "dvlp www"
   },
   "devDependencies": {
-    "dvlp": "^11.0.0",
-    "lit-html": "^1.3.0"
+    "dvlp": "^11.0.0"
   },
   "dependencies": {
-    "@nrk/reactive-element": "^6.0.0"
+    "@nrk/reactive-element": "^6.0.0",
+    "lit-html": "^1.3.0"
   },
   "prettier": {
     "singleQuote": true

--- a/www/index.css
+++ b/www/index.css
@@ -1,0 +1,22 @@
+[data-container] {
+  border: 1px solid rgba(0, 255, 0, 0.4);
+  background-color: rgba(0, 255, 0, 0.2);
+}
+
+[data-focusable] {
+  padding: 5px;
+  margin: 10px;
+  border: 1px solid rgba(0, 0, 255, 0.4);
+  background-color: rgba(0, 0, 255, 0.2);
+}
+
+[data-active] {
+  font-weight: bold;
+}
+
+:focus {
+  outline: 0;
+  border: 1px solid rgba(255, 0, 0, 0.4);
+  border: 1px solid rgba(255, 0, 0, 0.4);
+  background-color: rgba(255, 0, 0, 0.2);
+}

--- a/www/index.html
+++ b/www/index.html
@@ -1,8 +1,163 @@
-<script type="module" src="./index.js"></script>
-<style>
-  tv-channel {
-    display: block;
-  }
-</style>
+<html>
+  <head>
+    <script type="module" src="./index.js"></script>
+    <link
+      href="https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="./index.css" />
+  </head>
+  <body>
+    <div class="w-3/4 container mx-auto">
+      <h1 class="text-3xl my-5">Front page</h1>
+      <div data-container title="front-page" class="flex flex-col">
+        <div data-container title="menu" class="flex justify-center">
+          <a data-active data-focusable title="home" href="#">Home</a>
+          <a data-focusable title="live" href="#">Live</a>
+          <a data-focusable title="search" href="#">Search</a>
+        </div>
+        <div title="sections" class="flex flex-col">
+          <div data-container title="row-1" class="flex h-64">
+            <a data-focusable class="flex-grow" title="plug-1" href="#"
+              >Plug 1</a
+            >
+          </div>
+          <div data-container title="row-2" class="flex h-32">
+            <a data-focusable class="flex-grow" title="plug-2" href="#"
+              >Plug 2</a
+            >
+            <a data-focusable class="flex-grow" title="plug-3" href="#"
+              >Plug 3</a
+            >
+          </div>
+          <div data-container title="row-3" class="flex h-24">
+            <a data-focusable class="flex-grow" title="plug-4" href="#"
+              >Plug 4</a
+            >
+            <a data-focusable class="flex-grow" title="plug-5" href="#"
+              >Plug 5</a
+            >
+            <a data-focusable class="flex-grow" title="plug-6" href="#"
+              >Plug 6</a
+            >
+            <a data-focusable class="flex-grow" title="plug-7" href="#"
+              >Plug 7</a
+            >
+            <a data-focusable class="flex-grow" title="plug-8" href="#"
+              >Plug 8</a
+            >
+          </div>
+          <div data-container title="row-4" class="flex h-32">
+            <a data-focusable class="flex-grow" title="plug-9" href="#"
+              >Plug 2</a
+            >
+            <a data-focusable class="flex-grow" title="plug-10" href="#"
+              >Plug 3</a
+            >
+          </div>
+        </div>
+      </div>
 
-<tv-live-page></tv-live-page>
+      <h1 class="text-3xl my-5">Search page</h1>
+      <div data-container title="search-page" class="flex flex-col">
+        <div data-container title="menu" class="flex justify-center">
+          <a data-focusable title="home" href="#">Home</a>
+          <a data-focusable title="live" href="#">Live</a>
+          <a data-active data-focusable title="search" href="#">Search</a>
+        </div>
+        <div class="flex">
+          <div data-container title="keyboard" class="flex flex-col w-1/3">
+            <div class="flex">
+              <a data-focusable title="space" class="flex-grow" href="#"
+                >Space</a
+              >
+              <a data-focusable title="delete" class="flex-grow" href="#"
+                >Delete</a
+              >
+              <a data-focusable title="numeric" class="flex-grow" href="#"
+                >123</a
+              >
+            </div>
+            <div class="flex">
+              <a data-focusable title="a" class="flex-grow" href="#">A</a>
+              <a data-focusable title="b" class="flex-grow" href="#">B</a>
+              <a data-focusable title="c" class="flex-grow" href="#">C</a>
+              <a data-focusable title="d" class="flex-grow" href="#">D</a>
+              <a data-focusable title="e" class="flex-grow" href="#">E</a>
+              <a data-focusable title="f" class="flex-grow" href="#">F</a>
+            </div>
+            <div class="flex">
+              <a data-focusable title="g" class="flex-grow" href="#">G</a>
+              <a data-focusable title="h" class="flex-grow" href="#">H</a>
+              <a data-focusable title="i" class="flex-grow" href="#">I</a>
+              <a data-focusable title="j" class="flex-grow" href="#">J</a>
+              <a data-focusable title="k" class="flex-grow" href="#">K</a>
+              <a data-focusable title="l" class="flex-grow" href="#">L</a>
+            </div>
+          </div>
+          <div data-container title="results" class="flex flex-col flex-grow">
+            <div class="flex h-32">
+              <a data-focusable title="plug-1" class="flex-grow" href="#"
+                >Plug 1</a
+              >
+              <a data-focusable title="plug-2" class="flex-grow" href="#"
+                >Plug 2</a
+              >
+              <a data-focusable title="plug-3" class="flex-grow" href="#"
+                >Plug 3</a
+              >
+            </div>
+            <div class="flex h-32">
+              <a data-focusable class="flex-grow" title="plug-4" href="#"
+                >Plug 4</a
+              >
+              <a data-focusable class="flex-grow" title="plug-5" href="#"
+                >Plug 5</a
+              >
+              <a data-focusable class="flex-grow" title="plug-6" href="#"
+                >Plug 6</a
+              >
+            </div>
+            <div class="flex h-32">
+              <a data-focusable class="w-1/3" title="plug-4" href="#">Plug 7</a>
+              <a data-focusable class="w-1/3" title="plug-5" href="#">Plug 8</a>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <h1 class="text-3xl my-5">Series page</h1>
+      <div data-container title="series-page" class="flex flex-col">
+        <div data-container title="menu" class="flex justify-center">
+          <a data-focusable title="home" href="#">Home</a>
+          <a data-focusable title="live" href="#">Live</a>
+          <a data-active data-focusable title="search" href="#">Search</a>
+        </div>
+        <div class="flex">
+          <div data-container title="episode-list" class="flex flex-col w-1/3">
+            <a data-focusable title="episode-1" href="#">Episode 1</a>
+            <a data-focusable title="episode-2" href="#">Episode 2</a>
+            <a data-focusable title="episode-3" href="#">Episode 3</a>
+            <a data-focusable data-active title="episode-4" href="#"
+              >Episode 4</a
+            >
+            <a data-focusable title="episode-5" href="#">Episode 5</a>
+            <a data-focusable title="episode-6" href="#">Episode 6</a>
+            <a data-focusable title="episode-7" href="#">Episode 7</a>
+            <a data-focusable title="episode-8" href="#">Episode 8</a>
+            <a data-focusable title="episode-9" href="#">Episode 9</a>
+            <a data-focusable title="episode-10" href="#">Episode 10</a>
+          </div>
+          <div data-container title="episode" class="flex flex-col w-2/3">
+            <div class="h-64 bg-red-500"></div>
+            Hjemme starter Guillaume "Malotru" Debailly opplæringen av en ny
+            agent, Marina Loiseau. I mellomtiden mister byrået kontakten med
+            agent Cyclone når han blir arrestert for fyllekjøring i Algerie.
+
+            <button data-focusable title="read-more" href="#">Read more</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
A continuation of #2 that supports nested focus containers. By nesting containers we avoid many edge-cases that are hard to solve by adding weighting or similar.

- Searches for the closest candidate by starting from `activeElement`'s container. If no valid candidates are found, it searches for the closest container, and then for its closest candidate.
- By setting `preferActive` when moving between containers we ensure any `data-focusable` that also has `data-active` is preferred over any other candidate within a container.

NOTE: `data-focusable`, `data-container` and `data-active` should eventually be replaced by actual selectors such as `a, button:not([disabled])` etc.
## Preview

https://tv-focus-experiments-git-nested-focus-containers.simen.vercel.app

## Todo

- Improve closest algorithm by factoring in things like reading direction.